### PR TITLE
Add trainers for the pretraining and backtranslation tasks

### DIFF
--- a/spear_tts_pytorch/__init__.py
+++ b/spear_tts_pytorch/__init__.py
@@ -1,4 +1,9 @@
 from spear_tts_pytorch.spear_tts_pytorch import (
     TextToSemantic,
-    SpeechSpeechPretrainWrapper
+    SpeechSpeechPretrainWrapper,
+    SemanticToTextWrapper,
+)
+from spear_tts_pytorch.trainer import (
+    SpeechSpeechPretrainer,
+    SemanticToTextTrainer
 )

--- a/spear_tts_pytorch/trainer.py
+++ b/spear_tts_pytorch/trainer.py
@@ -1,0 +1,549 @@
+import re
+from pathlib import Path
+from shutil import rmtree
+
+from beartype import beartype
+from beartype.typing import Union, Optional
+
+import torch
+from torch import nn
+from torch.optim.lr_scheduler import CosineAnnealingLR
+from torch.utils.data import Dataset, random_split
+
+from audiolm_pytorch import FairseqVQWav2Vec, HubertWithKmeans
+from audiolm_pytorch.data import get_dataloader
+from audiolm_pytorch.optimizer import get_optimizer
+
+from spear_tts_pytorch.spear_tts_pytorch import SpeechSpeechPretrainWrapper, TextToSemantic, SemanticToTextWrapper
+
+from accelerate import Accelerator, DistributedType
+
+
+# make sure only one trainer is instantiated
+
+ONE_TRAINER_INSTANTIATED = False
+
+def check_one_trainer():
+    global ONE_TRAINER_INSTANTIATED
+    assert not ONE_TRAINER_INSTANTIATED, 'only one Trainer can be instantiated at a time for training'
+    ONE_TRAINER_INSTANTIATED = True
+
+
+# helpers
+
+def exists(val):
+    return val is not None
+
+def noop(*args, **kwargs):
+    pass
+
+def cycle(dl):
+    while True:
+        for data in dl:
+            yield data
+
+def cast_tuple(t):
+    return t if isinstance(t, (tuple, list)) else (t,)
+
+def yes_or_no(question):
+    answer = input(f'{question} (y/n) ')
+    return answer.lower() in ('yes', 'y')
+
+def accum_log(log, new_logs):
+    for key, new_value in new_logs.items():
+        old_value = log.get(key, 0.)
+        log[key] = old_value + new_value
+    return log
+
+def checkpoint_num_steps(checkpoint_path):
+    """Returns the number of steps trained from a checkpoint based on the filename.
+
+    Filename format assumed to be something like "/path/to/speech.speech.20000.pt" which is
+    for 20k train steps. Returns 20000 in that case.
+    """
+    results = re.findall(r'\d+', str(checkpoint_path))
+
+    if len(results) == 0:
+        return 0
+
+    return int(results[-1])
+
+
+class SpeechSpeechPretrainer(nn.Module):
+    @beartype
+    def __init__(
+        self,
+        model: TextToSemantic,
+        wav2vec: Optional[Union[FairseqVQWav2Vec, HubertWithKmeans]],
+        *,
+        num_train_steps,
+        num_warmup_steps,
+        batch_size,
+        dataset: Optional[Dataset] = None,
+        data_max_length = None,
+        data_max_length_seconds = None,
+        deletion_prob: float = 0.6,
+        reconstruct_seq: bool = False,
+        folder = None,
+        lr = 3e-4,
+        initial_lr = 1e-5,
+        grad_accum_every = 1,
+        wd = 0.,
+        max_grad_norm = 0.5,
+        valid_frac = 0.05,
+        random_split_seed = 42,
+        save_results_every = 100,
+        save_model_every = 1000,
+        results_folder = './results',
+        accelerate_kwargs: dict = dict(),
+        split_batches = False,
+        drop_last = False,
+        force_clear_prev_results = None
+    ):
+        super().__init__()
+        check_one_trainer()
+
+        self.accelerator = Accelerator(
+            split_batches = split_batches,
+            **accelerate_kwargs
+        )
+
+        self.model = model
+        self.wav2vec = wav2vec
+
+        self.train_wrapper = SpeechSpeechPretrainWrapper(
+            model = model,
+            wav2vec = wav2vec,
+            deletion_prob = deletion_prob,
+            reconstruct_seq = reconstruct_seq
+        )
+
+        self.register_buffer('steps', torch.Tensor([0]))
+
+        self.num_train_steps = num_train_steps
+        self.num_warmup_steps = num_warmup_steps
+        self.batch_size = batch_size
+        self.grad_accum_every = grad_accum_every
+
+        # optimizers
+        self.lr = lr
+        self.initial_lr = initial_lr
+        self.optim = get_optimizer(model.parameters(), lr = lr, wd = wd)
+        self.scheduler = CosineAnnealingLR(self.optim, T_max = num_train_steps)
+
+        # max grad norm
+
+        self.max_grad_norm = max_grad_norm
+
+        # create dataset
+
+        self.ds = dataset
+
+        # split for validation
+
+        if valid_frac > 0:
+            train_size = int((1 - valid_frac) * len(self.ds))
+            valid_size = len(self.ds) - train_size
+            self.ds, self.valid_ds = random_split(self.ds, [train_size, valid_size], generator = torch.Generator().manual_seed(random_split_seed))
+            self.print(f'training with dataset of {len(self.ds)} samples and validating with randomly splitted {len(self.valid_ds)} samples')
+        else:
+            self.valid_ds = self.ds
+            self.print(f'training with shared training and valid dataset of {len(self.ds)} samples')
+
+        assert len(self.ds) >= batch_size, 'dataset must have sufficient samples for training'
+        assert len(self.valid_ds) >= batch_size, f'validation dataset must have sufficient number of samples (currently {len(self.valid_ds)}) for training'
+
+        # dataloader
+
+        self.dl = get_dataloader(self.ds, batch_size = batch_size, shuffle = True, drop_last = drop_last)
+
+        self.valid_dl = get_dataloader(self.valid_ds, batch_size = batch_size, shuffle = True, drop_last = drop_last)
+
+        # prepare with accelerator
+
+        (
+            self.train_wrapper,
+            self.optim,
+            self.scheduler,
+            self.dl,
+            self.valid_dl
+        ) = self.accelerator.prepare(
+            self.train_wrapper,
+            self.optim,
+            self.scheduler,
+            self.dl,
+            self.valid_dl
+        )
+
+        # dataloader iterators
+
+        self.dl_iter = cycle(self.dl)
+        self.valid_dl_iter = cycle(self.valid_dl)
+
+        self.save_model_every = save_model_every
+        self.save_results_every = save_results_every
+
+        self.results_folder = Path(results_folder)
+
+        if self.is_main and force_clear_prev_results is True or (not exists(force_clear_prev_results) and len([*self.results_folder.glob('**/*')]) > 0 and yes_or_no('do you want to clear previous experiment checkpoints and results?')):
+            rmtree(str(self.results_folder))
+
+        self.results_folder.mkdir(parents = True, exist_ok = True)
+        
+        hps = {"num_train_steps": num_train_steps, "num_warmup_steps": num_warmup_steps, "data_max_length": data_max_length, "learning_rate": lr, "initial_learning_rate": lr}
+        self.accelerator.init_trackers("speechspeech", config=hps)
+
+    def save(self, path):
+        pkg = dict(
+            model = self.accelerator.get_state_dict(self.model),
+            optim = self.optim.state_dict(),
+            scheduler = self.scheduler.state_dict()
+        )
+        torch.save(pkg, path)
+
+    def load(self, path):
+        model = self.accelerator.unwrap_model(self.model)
+        pkg = model.load(path)
+
+        self.optim.load_state_dict(pkg['optim'])
+        self.scheduler.load_state_dict(pkg['scheduler'])
+
+        # + 1 to start from the next step and avoid overwriting the last checkpoint
+        self.steps = torch.tensor([checkpoint_num_steps(path) + 1], device=self.device)
+
+    def print(self, msg):
+        self.accelerator.print(msg)
+
+    def generate(self, *args, **kwargs):
+        return self.train_wrapper.generate(*args, **kwargs)
+
+    @property
+    def device(self):
+        return self.accelerator.device
+
+    @property
+    def is_distributed(self):
+        return not (self.accelerator.distributed_type == DistributedType.NO and self.accelerator.num_processes == 1)
+
+    @property
+    def is_main(self):
+        return self.accelerator.is_main_process
+
+    @property
+    def is_local_main(self):
+        return self.accelerator.is_local_main_process
+
+    def warmup(self, step):
+        if step < self.num_warmup_steps:
+            return self.initial_lr + (self.lr - self.initial_lr) * step / self.num_warmup_steps
+        else:
+            return self.lr
+    
+    def train_step(self):
+        steps = int(self.steps.item())
+
+        self.model.train()
+        
+        # adjust the lr according to the schedule
+        
+        if steps < self.num_warmup_steps:
+            # Apply warmup
+            lr = self.warmup(steps)
+            for param_group in self.optim.param_groups:
+                param_group['lr'] = lr
+        else:
+            # After warmup period, start to apply CosineAnnealingLR
+            self.scheduler.step()
+
+        # logs
+
+        logs = {}
+
+        # update vae (generator)
+
+        for _ in range(self.grad_accum_every):
+            x, = next(self.dl_iter)
+
+            loss = self.train_wrapper(x)
+
+            self.accelerator.backward(loss / self.grad_accum_every)
+
+            accum_log(logs, {'loss': loss.item() / self.grad_accum_every})
+
+        if exists(self.max_grad_norm):
+            self.accelerator.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)
+
+        self.optim.step()
+        self.optim.zero_grad()
+
+        # log
+
+        self.print(f"{steps}: loss: {logs['loss']}")
+        self.accelerator.log({"train_loss": logs['loss']}, step=steps)
+
+        # sample results every so often
+
+        self.accelerator.wait_for_everyone()
+
+        if self.is_main and not (steps % self.save_results_every):
+            x, = next(self.valid_dl_iter)
+
+            with torch.inference_mode():
+                self.train_wrapper.eval()
+                valid_loss = self.train_wrapper(x)
+
+            self.print(f'{steps}: valid loss {valid_loss}')
+            self.accelerator.log({"valid_loss": valid_loss}, step=steps)
+
+        # save model every so often
+
+        if self.is_main and not (steps % self.save_model_every):
+            model_path = str(self.results_folder / f'speech.speech.{steps}.pt')
+            self.save(model_path)
+
+            self.print(f'{steps}: saving model to {str(self.results_folder)}')
+
+        self.steps += 1
+        return logs
+
+    def train(self, log_fn = noop):
+        while self.steps < self.num_train_steps:
+            logs = self.train_step()
+            log_fn(logs)
+
+        self.print('training complete')
+
+
+class SemanticToTextTrainer(nn.Module):
+    @beartype
+    def __init__(
+        self,
+        model: TextToSemantic,
+        *,
+        num_train_steps,
+        num_warmup_steps,
+        batch_size,
+        dataset: Optional[Dataset] = None,
+        data_max_length = None,
+        lr = 3e-4,
+        initial_lr = 1e-5,
+        grad_accum_every = 1,
+        wd = 0.,
+        max_grad_norm = 0.5,
+        valid_frac = 0.05,
+        random_split_seed = 42,
+        save_results_every = 100,
+        save_model_every = 1000,
+        results_folder = './results',
+        accelerate_kwargs: dict = dict(),
+        split_batches = False,
+        drop_last = False,
+        force_clear_prev_results = None
+    ):
+        super().__init__()
+        check_one_trainer()
+
+        self.accelerator = Accelerator(
+            split_batches = split_batches,
+            **accelerate_kwargs
+        )
+
+        self.model = model
+
+        self.train_wrapper = SemanticToTextWrapper(model = model)
+
+        self.register_buffer('steps', torch.Tensor([0]))
+
+        self.num_train_steps = num_train_steps
+        self.num_warmup_steps = num_warmup_steps
+        self.batch_size = batch_size
+        self.grad_accum_every = grad_accum_every
+
+        # optimizers
+        self.lr = lr
+        self.initial_lr = initial_lr
+        self.optim = get_optimizer(model.parameters(), lr = lr, wd = wd)
+        self.scheduler = CosineAnnealingLR(self.optim, T_max = num_train_steps)
+
+        # max grad norm
+
+        self.max_grad_norm = max_grad_norm
+
+        # create dataset
+
+        self.ds = dataset
+
+        # split for validation
+
+        if valid_frac > 0:
+            train_size = int((1 - valid_frac) * len(self.ds))
+            valid_size = len(self.ds) - train_size
+            self.ds, self.valid_ds = random_split(self.ds, [train_size, valid_size], generator = torch.Generator().manual_seed(random_split_seed))
+            self.print(f'training with dataset of {len(self.ds)} samples and validating with randomly splitted {len(self.valid_ds)} samples')
+        else:
+            self.valid_ds = self.ds
+            self.print(f'training with shared training and valid dataset of {len(self.ds)} samples')
+
+        assert len(self.ds) >= batch_size, 'dataset must have sufficient samples for training'
+        assert len(self.valid_ds) >= batch_size, f'validation dataset must have sufficient number of samples (currently {len(self.valid_ds)}) for training'
+
+        # dataloader
+
+        self.dl = get_dataloader(self.ds, batch_size = batch_size, shuffle = True, drop_last = drop_last)
+
+        self.valid_dl = get_dataloader(self.valid_ds, batch_size = batch_size, shuffle = True, drop_last = drop_last)
+
+        # prepare with accelerator
+
+        (
+            self.train_wrapper,
+            self.optim,
+            self.scheduler,
+            self.dl,
+            self.valid_dl
+        ) = self.accelerator.prepare(
+            self.train_wrapper,
+            self.optim,
+            self.scheduler,
+            self.dl,
+            self.valid_dl
+        )
+
+        # dataloader iterators
+
+        self.dl_iter = cycle(self.dl)
+        self.valid_dl_iter = cycle(self.valid_dl)
+
+        self.save_model_every = save_model_every
+        self.save_results_every = save_results_every
+
+        self.results_folder = Path(results_folder)
+
+        if self.is_main and force_clear_prev_results is True or (not exists(force_clear_prev_results) and len([*self.results_folder.glob('**/*')]) > 0 and yes_or_no('do you want to clear previous experiment checkpoints and results?')):
+            rmtree(str(self.results_folder))
+
+        self.results_folder.mkdir(parents = True, exist_ok = True)
+        
+        hps = {"num_train_steps": num_train_steps, "num_warmup_steps": num_warmup_steps, "data_max_length": data_max_length, "learning_rate": lr, "initial_learning_rate": lr}
+        self.accelerator.init_trackers("speechspeech", config=hps)
+
+    def save(self, path):
+        pkg = dict(
+            model = self.accelerator.get_state_dict(self.model),
+            optim = self.optim.state_dict(),
+            scheduler = self.scheduler.state_dict()
+        )
+        torch.save(pkg, path)
+
+    def load(self, path, restore_optimzier = True):
+        model = self.accelerator.unwrap_model(self.model)
+        pkg = model.load(path)
+
+        if restore_optimzier:
+            self.optim.load_state_dict(pkg['optim'])
+            self.scheduler.load_state_dict(pkg['scheduler'])
+
+            # + 1 to start from the next step and avoid overwriting the last checkpoint
+            self.steps = torch.tensor([checkpoint_num_steps(path) + 1], device=self.device)
+
+    def print(self, msg):
+        self.accelerator.print(msg)
+
+    def generate(self, *args, **kwargs):
+        return self.train_wrapper.generate(*args, **kwargs)
+
+    @property
+    def device(self):
+        return self.accelerator.device
+
+    @property
+    def is_distributed(self):
+        return not (self.accelerator.distributed_type == DistributedType.NO and self.accelerator.num_processes == 1)
+
+    @property
+    def is_main(self):
+        return self.accelerator.is_main_process
+
+    @property
+    def is_local_main(self):
+        return self.accelerator.is_local_main_process
+
+    def warmup(self, step):
+        if step < self.num_warmup_steps:
+            return self.initial_lr + (self.lr - self.initial_lr) * step / self.num_warmup_steps
+        else:
+            return self.lr
+    
+    def train_step(self):
+        steps = int(self.steps.item())
+
+        self.model.train()
+        
+        # adjust the lr according to the schedule
+        
+        if steps < self.num_warmup_steps:
+            # Apply warmup
+            lr = self.warmup(steps)
+            for param_group in self.optim.param_groups:
+                param_group['lr'] = lr
+        else:
+            # After warmup period, start to apply CosineAnnealingLR
+            self.scheduler.step()
+
+        # logs
+
+        logs = {}
+
+        # update vae (generator)
+
+        for _ in range(self.grad_accum_every):
+            semantic_token_ids, grapheme_token_ids = next(self.dl_iter)
+
+            loss = self.train_wrapper(semantic_token_ids = semantic_token_ids, grapheme_token_ids = grapheme_token_ids)
+
+            self.accelerator.backward(loss / self.grad_accum_every)
+
+            accum_log(logs, {'loss': loss.item() / self.grad_accum_every})
+
+        if exists(self.max_grad_norm):
+            self.accelerator.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)
+
+        self.optim.step()
+        self.optim.zero_grad()
+
+        # log
+
+        self.print(f"{steps}: loss: {logs['loss']}")
+        self.accelerator.log({"train_loss": logs['loss']}, step=steps)
+
+        # sample results every so often
+
+        self.accelerator.wait_for_everyone()
+
+        if self.is_main and not (steps % self.save_results_every):
+            semantic_token_ids, grapheme_token_ids = next(self.valid_dl_iter)
+
+            with torch.inference_mode():
+                self.train_wrapper.eval()
+                valid_loss = self.train_wrapper(semantic_token_ids = semantic_token_ids, grapheme_token_ids = grapheme_token_ids)
+
+            self.print(f'{steps}: valid loss {valid_loss}')
+            self.accelerator.log({"valid_loss": valid_loss}, step=steps)
+
+        # save model every so often
+
+        if self.is_main and not (steps % self.save_model_every):
+            model_path = str(self.results_folder / f'text.semantic.{steps}.pt')
+            self.save(model_path)
+
+            self.print(f'{steps}: saving model to {str(self.results_folder)}')
+
+        self.steps += 1
+        return logs
+
+    def train(self, log_fn = noop):
+        while self.steps < self.num_train_steps:
+            logs = self.train_step()
+            log_fn(logs)
+
+        self.print('training complete')


### PR DESCRIPTION
I was able to get both the pretraining and backtranslation tasks working using graphemes, as described in Appendix G in the paper. It required some model tweaks to allow freezing the encoder & specifying a target mask when the modalities are different. I added beam search as optional in the generation loop since it seems to outperform temperature sampling for the backtranslation task.

I also fixed an issue with loading checkpoints and to allow restoring checkpoints without the optimizer state. This makes both resuming training runs and fine-tuning from the pretrained model possible.

This might be too big of a change to take, but I thought it might be useful for others! Let me know if you'd prefer me to break it up into smaller changes if that's helpful.

Here's an example of a sample generation using the (severely undertrained 🙈, in my case) models:

```
semantic_token_ids: tensor([[ 17, 296, 114, 258, 271,  31,  39,  54, 142, 397, 345, 141, 281, 269,
           9, 142, 221, 196, 309, 479, 331, 307, 405, 206, 167, 385, 233,  82,
         227, 419, 483, 225, 226,  82, 209,  83, 145, 253, 368, 453, 168, 177,
         457, 196, 217, 473, 476, 171, 252, 422, 186, 162, 232, 172, 115, 273,
         444, 360, 434, 339, 203, 381, 117, 404, 229,  82, 247, 126, 326, 101,
         149, 228,  82, 289, 320,   7, 217, 473, 286, 468, 134, 175, 359,  81,
         166, 324,   3, 440, 188,  44,  38, 225, 164, 205, 261,  25, 485, 286,
         468, 406, 337,  41, 246,  19, 454, 229, 414,  82,  80,  82,  80,  82,
         140, 108, 119, 351, 278, 330, 388,  33, 195, 471, 368, 310, 107, 447,
           6, 272, 161, 397, 345, 333, 220, 402, 478,  66, 482, 232, 172, 115,
         273, 106, 499, 306, 396, 245, 143, 458, 259, 192, 445, 351, 486, 460,
         368, 342,  54, 224, 168, 494, 275, 203, 381,  48, 417, 421, 128, 491,
         193,  17]], device='mps:0')

Reference: This was not, as it may seem, merely a theory tinged with sarcasm.
 52%|█████▏    | 67/128 [00:01<00:01, 47.14it/s]
Backtranslated (sampling): This was not as it may seem, merely a theory, tinged, with sarcasm.
 52%|█████▏    | 67/128 [00:02<00:02, 25.31it/s]
Backtranslated (beam size 4): This was not, as it may seem, merely a theory, tinged with sarcasm.
```